### PR TITLE
Add missing *-256color TERM definitions

### DIFF
--- a/src/dir_colors
+++ b/src/dir_colors
@@ -18,25 +18,38 @@ TERM console
 TERM cygwin
 TERM dtterm
 TERM dvtm
+TERM dvtm-256color
 TERM Eterm
 TERM eterm-color
 TERM fbterm
 TERM gnome
+TERM gnome-256color
 TERM hurd
 TERM jfbterm
 TERM konsole
+TERM konsole-256color
 TERM kterm
 TERM linux
 TERM linux-c
 TERM mlterm
 TERM putty
+TERM putty-256color
 TERM rxvt*
+TERM rxvt-unicode
+TERM rxvt-256color
+TERM rxvt-unicode256
 TERM screen*
+TERM screen-256color
 TERM st
+TERM st-256color
 TERM terminator
 TERM tmux*
+TERM tmux-256color
 TERM vt100
 TERM xterm*
+TERM xterm-color
+TERM xterm-88color
+TERM xterm-256color
 
 #+-----------------+
 #+ Global Defaults +


### PR DESCRIPTION
> **Bound to** #4 

This PR fixes uncolorized output for all `*-256-*` terminal emulators.