### PR TITLE
Add basic programmer's colors 

### DIFF
--- a/src/dir_colors
+++ b/src/dir_colors
@@ -178,7 +178,10 @@ STICKY 04;37;44
 .cmd 01;36
 .com 01;36
 .exe 01;36
+.ps1 01;36
+.psm1 01;36
 .reg 01;36
+.sh 01;36
 
 #+--- Installable or indirectly executable files ---+
 .woff 36
@@ -272,34 +275,37 @@ STICKY 04;37;44
 #+--- Source code files ---+
 .cc 32
 .cpp 32
-.h 32
 .cs 32
 .fs 32
-.rs 32
 .go 32
+.h 32
+.htm 32
+.html 32
+.java 32
 .js 32
 .jsx 32
+.lua 32
+.m 32
+.pug 32
+.py 32
+.rs 32
+.scala 32
+.swift 32
 .ts 32
 .tsx 32
-.lua 32
-.java 32
-.scala 32
-.py 32
-.m 32
-.swift 32
 
 #+--- Project-like files with source code ---+
-.htm 31
-.html 31
-.pug 31
 .csproj 31
 .vcxproj 31
+.sfproj 31
+.deployproj 31
 .sln 31
 
 #+--- Text and configuration files ---+
 .csv 33
 .json 33
 .md 33
+.nuspec 33
 .txt 33
 .xml 33
 .yaml 33

--- a/src/dir_colors
+++ b/src/dir_colors
@@ -305,7 +305,6 @@ STICKY 04;37;44
 .yaml 33
 .yml 33
 .toml 33
-.nuspec 33 # NuGet specification
 
 #+--- Stylesheets ---+
 .css 35

--- a/src/dir_colors
+++ b/src/dir_colors
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Sven Greb <development@svengreb.de>
 
 # Project:    Nord dircolors
-# Version:    0.2.0
+# Version:    0.3.0
 # Repository: https://github.com/arcticicestudio/nord-dircolors
 # License:    MIT
 
@@ -180,6 +180,15 @@ STICKY 04;37;44
 .exe 01;36
 .reg 01;36
 
+#+--- Installable or indirectly executable files ---+
+.woff 36
+.woff2 36
+.eot 36
+.otf 36
+.ttf 36
+.jar 36
+.apk 36
+
 #+--- Ignores ---+
 *~ 02;37
 .bak 02;37
@@ -192,6 +201,11 @@ STICKY 04;37;44
 .ORIG 02;37
 .swo 02;37
 .swp 02;37
+
+#+--- Binary files ---+
+.dll 02;37
+.so 02;37
+.o 02;37
 
 #+--- Images ---+
 .bmp 32
@@ -254,3 +268,47 @@ STICKY 04;37;44
 .vob 32
 .webm 32
 .wmv 32
+
+#+--- Source code files ---+
+.cc 32
+.cpp 32
+.h 32
+.cs 32
+.fs 32
+.rs 32
+.go 32
+.js 32
+.jsx 32
+.ts 32
+.tsx 32
+.lua 32
+.java 32
+.scala 32
+.py 32
+.m 32
+.swift 32
+
+#+--- Project-like files with source code ---+
+.htm 31
+.html 31
+.pug 31
+.csproj 31
+.vcxproj 31
+.sln 31
+
+#+--- Text and configuration files ---+
+.csv 33
+.json 33
+.md 33
+.txt 33
+.xml 33
+.yaml 33
+.yml 33
+.toml 33
+.nuspec 33 # NuGet specification
+
+#+--- Stylesheets ---+
+.css 35
+.scss 35
+.sass 35
+.less 35


### PR DESCRIPTION
Coloring the files which programmers are often dealing with:
- Source code files for popular languages. Colored in green like documents because that's what they essentially are.
- Project-like files (c-sharp projects, solutions, etc) stand out in red for an easier identification among the source code files.
- Configuration files (json, yaml, etc) also stand out in yellow for easier identification.
- Common binary files. Colored as temp/ignores because essentially they can be reconstructed from sources.
- Stylesheets colored in magenta to signal that this is UI related. P.S. I'd also propose to color images/videos in magenta too. Then magenta would represent everything "vivid".

The list is not exhaustive, we can add more popular types of files later if needed.

Fixes #22.